### PR TITLE
Test to add verify middleware for frontend routing

### DIFF
--- a/frontend/src/app/bookmark/articles/page.tsx
+++ b/frontend/src/app/bookmark/articles/page.tsx
@@ -1,0 +1,9 @@
+const page = () => {
+	return (
+		<div>
+			<h1>Articles</h1>
+		</div>
+	);
+};
+
+export default page;

--- a/frontend/src/app/bookmark/search-history/page.tsx
+++ b/frontend/src/app/bookmark/search-history/page.tsx
@@ -1,0 +1,9 @@
+const page = () => {
+	return (
+		<div>
+			<h1>Search History</h1>
+		</div>
+	);
+};
+
+export default page;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,15 @@
 import { UserButton } from "@stackframe/stack";
+import Link from "next/link";
 
 export default function Page() {
-	return <UserButton />;
+	return (
+		<div>
+			<UserButton />
+			<div>
+				<Link href="/bookmark/articles">/bookmark/articles</Link>
+				<br />
+				<Link href="/bookmark/search-history">/bookmark/search-history</Link>
+			</div>
+		</div>
+	);
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,16 @@
+import { stackServerApp } from "@/stack";
+import { NextRequest, NextResponse } from "next/server";
+
+const middleware = async (request: NextRequest) => {
+	const user = await stackServerApp.getUser();
+	if (!user) {
+		return NextResponse.redirect(new URL("/handler/sign-in", request.url));
+	}
+	return NextResponse.next();
+};
+
+export const config = {
+	matcher: "/bookmark/:path*",
+};
+
+export default middleware;

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,5 +1,5 @@
 import { stackServerApp } from "@/stack";
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
 const middleware = async (request: NextRequest) => {
 	const user = await stackServerApp.getUser();


### PR DESCRIPTION
## Issue

## 検索用キーワード
middleware

## 説明
記事ブックマーク `/bookmark/articles`, 検索履歴ブックマーク `/bookmark/search-history` のルーティングを仮設置し、ログインしていなければアクセスできないようにした。

## 動作確認
`/` に簡単なリンクを設置した。ログイン前にリンクを踏むと Stack Auth のデフォルトのサインイン画面に飛ばされ、ログイン後にリンクを踏むと正常にルーティングが行われることを確認してください。

## その他、相談したいこと等
